### PR TITLE
Update Menu.js

### DIFF
--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -146,7 +146,7 @@ const styles2 = css`
             padding: 0;
             justify-content: space-around;
             justify-content: flex-start;
-            align-items: center;
+            align-items: left;
             min-height: 50%;
             display: flex;
             flex-direction: column;


### PR DESCRIPTION
Align the side tabbed menu to the left so the tabs are flush with the content window. Line 149 change 'align-items: center' to 'align-items: left'